### PR TITLE
Create user documents on registration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3434,6 +3434,12 @@
         "mime-types": "~2.1.18"
       }
     },
+    "uid": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/uid/-/uid-0.0.2.tgz",
+      "integrity": "sha1-XkpdS3gTi09w+J/Tx2/FmqnS8QM=",
+      "dev": true
+    },
     "uid-number": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "node-fetch": "^2.1.2",
     "pino-elasticsearch": "^2.2.1",
     "pino-tee": "^0.2.0"
+  },
+  "devDependencies": {
+    "uid": "0.0.2"
   }
 }

--- a/src/controllers/auth/register/controller.js
+++ b/src/controllers/auth/register/controller.js
@@ -1,30 +1,34 @@
 const Account = require('../../../models/account');
 const bcrypt = require('bcrypt');
 const ErrorResponse = require('../../../responses/error-response');
+const UserService = require('../../../utils/user-serice');
 
 module.exports.register = async (req, res) => {
-	let { password, username } = req.body;
-	username = req.sanitize(username);
-	// Check if there is such a user
-	const user = await Account.findOne({ username });
-	if (user !== null) {
-		// User already exsists
-		const errorCode = 'UserExists';
-		req.log.info({ errorCode, username });
-		throw new ErrorResponse(409, errorCode, 'Username exists');
-	}
+  let { password, username } = req.body;
+  username = req.sanitize(username);
+  // Check if there is such a user
+  const user = await Account.findOne({ username });
+  if (user !== null) {
+    // User already exsists
+    const errorCode = 'UserExists';
+    req.log.info({ errorCode, username });
+    throw new ErrorResponse(409, errorCode, 'Username exists');
+  }
 
-	// Create new user
-	let newUser = new Account({
-		password: await bcrypt.hash(password, 10),
-		username,
-	});
+  // Create new user
+  let newUser = new Account({
+    password: await bcrypt.hash(password, 10),
+    username,
+  });
 
-	// Save in DB
-	const result = await newUser.save();
+  // Save in DB
+  const result = await newUser.save();
 
-	// Send the response
-	res.status(201).json({
-		success: true,
-	});
+  // Tell the user service to create a new user entry
+  const serviceJob = (new UserService()).createUserDocument(username);
+
+  // Send the response
+  res.status(201).json({
+    success: true,
+  });
 };

--- a/src/utils/user-serice.js
+++ b/src/utils/user-serice.js
@@ -1,0 +1,41 @@
+
+const fetch = require('node-fetch');
+
+module.exports = class UserService {
+  constructor(http = fetch) {
+    this.httpMethod = http;
+    this.baseUrl = 'https://volunteero-altar.herokuapp.com/altar/v1/users';
+  }
+
+  createUserDocument(username) {
+    const body = {
+      username,
+      points: 0
+    };
+    const headers = {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json'
+    }
+    return this.httpMethod(this.baseUrl, {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers
+    });
+  }
+
+  removeUserDocument(username) {
+    const body = {
+      username
+    };
+    const headers = {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json'
+    }
+    const route = `${this.baseUrl}/delete`;
+    return this.httpMethod(route, {
+      method: 'PUT',
+      body: JSON.stringify(body),
+      headers
+    });
+  }
+}

--- a/tests/user-service.test.js
+++ b/tests/user-service.test.js
@@ -1,0 +1,34 @@
+'use strict';
+const chai = require('chai');
+const assert = chai.assert;
+const UserService = require('../src/utils/user-serice');
+const fetch = require('node-fetch');
+const uid = require('uid');
+
+describe.only('User Service Testing', () => {
+  let username = '';
+
+  it('Should use fetch by default', () => {
+    const us = new UserService();
+    assert.equal(us.httpMethod, fetch);
+  });
+
+  before(() => {
+    username = uid();
+    console.log(`testing for the username: ${username}`)
+  })
+
+  it('Should create a user document with the specified username', () => {
+    const us = new UserService();
+    return us.createUserDocument(username).then((result) => {
+      assert.equal(result.status, 201);
+    });
+  });
+
+  it('Should delete a user document with the specified username', () => {
+    const us = new UserService();
+    return us.removeUserDocument(username).then((result) => {
+      assert.equal(result.status, 200);
+    });
+  });
+})


### PR DESCRIPTION
**What**
When a user is registered, we automatically create a new user document for the fella

**Why**
Because the message queue is not used 😛 

**How**
Created the `user-service` util with two methods: `create` and `remove` and have written tests for it, so it is supposed to work. 